### PR TITLE
Fix for reading and seeking for filesystem

### DIFF
--- a/flask_storage/filesystem.py
+++ b/flask_storage/filesystem.py
@@ -157,3 +157,9 @@ class FileSystemStorageFile(StorageFile):
 
     def tell(self):
         return self.file.tell()
+
+    def read(self, size=-1):
+        return self.file.read(size)
+
+    def seek(self, offset, whence=os.SEEK_SET):
+        self.file.seek(offset, whence)


### PR DESCRIPTION
Pythons file object doesn't support `offset`, so any usage of read() caused issues.
